### PR TITLE
CPLAT-6186 Ensure that the webdev_proxy process always exits

### DIFF
--- a/bin/webdev_proxy.dart
+++ b/bin/webdev_proxy.dart
@@ -18,5 +18,5 @@ import 'package:webdev_proxy/src/executable.dart' as executable;
 
 /// Entrypoint for the `webdev_proxy` executable.
 void main(List<String> args) async {
-  exitCode = await executable.run(args);
+  exit(await executable.run(args));
 }


### PR DESCRIPTION
## Changes

When webdev_proxy starts a `webdev serve` child process and some other process connects to it (e.g. a chrome tab), the parent process will not exit on its own until the connected process stops listening, even if the `webdev serve` process is killed.

To solve this, the webdev_proxy exectuable now calls dart:io's `exit()` method rather than passively setting the `exitCode`, which will force the process to exit even in the above scenario.

## Testing

- Run `pub run webdev_proxy serve -- test`
- Load `http://localhost:8080` in a browser
- Return to terminal with running process and interrupt the process with a `ctrl + c`
- Verify that the process exits cleanly and does not hang