### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/bin/webdev_proxy.dart
+++ b/bin/webdev_proxy.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/command_utils_test.dart
+++ b/test/command_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/port_utils_test.dart
+++ b/test/port_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/proxy_server_test.dart
+++ b/test/proxy_server_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/sse_proxy_handler_test.dart
+++ b/test/sse_proxy_handler_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'dart:async';
 import 'dart:io';

--- a/test/web/index.dart
+++ b/test/web/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:html';
 
 import 'package:sse/client/sse_client.dart';

--- a/test/webdev_arg_utils_test.dart
+++ b/test/webdev_arg_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/webdev_proc_utils_test.dart
+++ b/test/webdev_proc_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/webdev_proxy_server_test.dart
+++ b/test/webdev_proxy_server_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/webdev_server_test.dart
+++ b/test/webdev_server_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)