### PR TITLE
CPLAT-15165 Fix bug when using `--hostname` option

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -1,0 +1,36 @@
+name: Dart CI
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'test_consume_*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [ 2.7.2, stable, dev ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v0.2
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Install dependencies
+        run: pub get
+
+      - name: Formatting
+        run: dartfmt -n --set-exit-if-changed .
+        if: always() && ${{ matrix.sdk }} == '2.7.2'
+
+      - name: Analysis
+        run: dartanalyzer .
+
+      - name: Tests
+        run: pub run test

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable, dev ]
+        sdk: [ stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -23,14 +23,14 @@ jobs:
           sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: Formatting
-        run: dartfmt -n --set-exit-if-changed .
-        if: always() && ${{ matrix.sdk }} == '2.7.2'
+        run: dart format --output=none --set-exit-if-changed .
+        if: always() && ${{ matrix.sdk }} == 'stable'
 
       - name: Analysis
-        run: dartanalyzer .
+        run: dart analyze
 
       - name: Tests
-        run: pub run test
+        run: dart test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+## 0.1.1
+
+- Fix bug when using `--hostname` that would cause the build daemon to fail to
+start.
+
 ## 0.1.0
 
 - Initial release!
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM google/dart:2.3
-RUN apt-get update -qq && rm -rf /var/lib/apt/lists/*
+FROM google/dart:2.13
 WORKDIR /build/
 ADD pubspec.yaml .
 RUN pub get
-ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
 FROM scratch

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,3 +1,4 @@
 concurrency: 1
 reporter: expanded
 retry: 2
+timeout: 60s

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -26,7 +26,7 @@ class WebdevProxy extends CommandRunner<int> {
   WebdevProxy()
       : super('webdev_proxy',
             'A simple dart proxy for `webdev serve` (uses the `shelf_proxy` package).') {
-    addCommand(new ServeCommand());
+    addCommand(ServeCommand());
     argParser.addFlag(verboseFlag, abbr: 'v', help: 'Enable verbose output.');
   }
 

--- a/lib/src/command_utils.dart
+++ b/lib/src/command_utils.dart
@@ -19,7 +19,7 @@ import 'package:args/args.dart';
 void assertNoPositionalArgsBeforeSeparator(
   String command,
   ArgResults argResults,
-  void usageException(String msg),
+  void Function(String msg) usageException,
 ) {
   if (argResults.rest.isEmpty) {
     return;

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -50,7 +50,7 @@ StringBuffer colorLog(LogRecord record, {bool verbose}) {
   }
 
   if (record.stackTrace != null && verbose) {
-    final trace = new Trace.from(record.stackTrace).terse;
+    final trace = Trace.from(record.stackTrace).terse;
     lines.add(trace);
   }
 
@@ -100,7 +100,7 @@ String humanReadable(Duration duration) {
 Future<T> logTimedAsync<T>(
   Logger logger,
   String description,
-  Future<T> action(), {
+  Future<T> Function() action, {
   Level level = Level.INFO,
 }) async {
   final watch = Stopwatch()..start();
@@ -118,7 +118,7 @@ Future<T> logTimedAsync<T>(
 T logTimedSync<T>(
   Logger logger,
   String description,
-  T action(), {
+  T Function() action, {
   Level level = Level.INFO,
 }) {
   final watch = Stopwatch()..start();

--- a/lib/src/port_utils.dart
+++ b/lib/src/port_utils.dart
@@ -14,11 +14,20 @@
 
 import 'dart:io';
 
-/// Returns a Future that completes with an open port that should be available
-/// for binding.
-Future<int> findAndReleaseOpenPort() async {
-  final socket = await ServerSocket.bind('localhost', 0);
-  final port = socket.port;
+/// Returns a port that is probably, but not definitely, not in use.
+///
+/// This has a built-in race condition: another process may bind this port at
+/// any time after this call has returned.
+Future<int> findUnusedPort() async {
+  int port;
+  ServerSocket socket;
+  try {
+    socket =
+        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
+  } on SocketException {
+    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  }
+  port = socket.port;
   await socket.close();
   return port;
 }

--- a/lib/src/serve_command.dart
+++ b/lib/src/serve_command.dart
@@ -137,7 +137,9 @@ class ServeCommand extends Command<int> {
     });
 
     // Parse the hostname to serve each dir on (defaults to 0.0.0.0)
-    final hostname = parseHostname(argResults.rest);
+    final hostnameResults = parseHostname(argResults.rest);
+    final hostname = hostnameResults.hostname;
+    final remainingArgs = hostnameResults.remainingArgs;
 
     // Parse the directory:port mappings that will be used by the proxy servers.
     // Each proxy will be mapped to a `webdev serve` instance on another port.
@@ -151,8 +153,8 @@ class ServeCommand extends Command<int> {
 
     // Start the underlying `webdev serve` process.
     webdevServer = await WebdevServer.start([
-      ...argResults.rest,
       if (hostname != 'localhost') '--hostname=$hostname',
+      ...remainingArgs,
       for (final dir in portsToServeByDir.keys)
         '$dir:${portsToProxyByDir[dir]}',
     ]);

--- a/lib/src/serve_command.dart
+++ b/lib/src/serve_command.dart
@@ -147,8 +147,7 @@ class ServeCommand extends Command<int> {
 
     // Find open ports for each of the directories to be served by webdev.
     final portsToProxyByDir = {
-      for (final dir in portsToServeByDir.keys)
-        dir: await findAndReleaseOpenPort()
+      for (final dir in portsToServeByDir.keys) dir: await findUnusedPort()
     };
 
     // Start the underlying `webdev serve` process.

--- a/lib/src/webdev_arg_utils.dart
+++ b/lib/src/webdev_arg_utils.dart
@@ -53,23 +53,34 @@ Map<String, int> parseDirectoryArgs(List<String> args) {
 /// [args] only if it is specified.
 ///
 /// Otherwise, returns a default of `'localhost'`.
-String parseHostname(List<String> args) {
+ParseHostnameResults parseHostname(List<String> args) {
+  String hostname = 'localhost';
+  final remainingArgs = <String>[];
+  var skipNext = false;
   for (var i = 0; i < args.length; i++) {
-    if (!args[i].startsWith('--hostname')) {
+    if (skipNext) {
+      skipNext = false;
       continue;
-    }
-    if (args[i].contains('=')) {
+    } else if (!args[i].startsWith('--hostname')) {
+      remainingArgs.add(args[i]);
+    } else if (args[i].contains('=')) {
       // --hostname=<value>
-      return args[i].split('=')[1];
-    }
-    if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      hostname = args[i].split('=')[1];
+    } else if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
       // --hostname <value>
-      return args[i + 1];
+      hostname = args[i + 1];
+      skipNext = true;
     }
   }
-  return 'localhost';
+  return ParseHostnameResults(hostname, remainingArgs);
 
   // TODO: Use when webdev `--hostname=any` support is released
   // HttpMultiServer supports `any` as a more flexible localhost.
   // return 'any';
+}
+
+class ParseHostnameResults {
+  final String hostname;
+  final List<String> remainingArgs;
+  ParseHostnameResults(this.hostname, this.remainingArgs);
 }

--- a/lib/src/webdev_arg_utils.dart
+++ b/lib/src/webdev_arg_utils.dart
@@ -54,7 +54,7 @@ Map<String, int> parseDirectoryArgs(List<String> args) {
 ///
 /// Otherwise, returns a default of `'localhost'`.
 ParseHostnameResults parseHostname(List<String> args) {
-  String hostname = 'localhost';
+  var hostname = 'localhost';
   final remainingArgs = <String>[];
   var skipNext = false;
   for (var i = 0; i < args.length; i++) {

--- a/lib/src/webdev_proc_utils.dart
+++ b/lib/src/webdev_proc_utils.dart
@@ -21,7 +21,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 /// The range of `webdev` versions with which this `webdev_proxy` package is
 /// compatible.
-final webdevCompatibility = new VersionConstraint.parse('>=1.0.1 <3.0.0');
+final webdevCompatibility = VersionConstraint.parse('>=1.0.1 <3.0.0');
 
 @visibleForTesting
 ProcessResult cachedWebdevVersionResult;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http_multi_server: ^2.1.0
   io: ^0.3.3
   logging: ^0.11.3+2
-  meta: ^1.1.7
+  meta: ">=1.1.7 <1.7.0" # pin to avoid issue in 1.7.0
   pedantic: ^1.7.0
   pub_semver: ^1.4.2
   shelf: ^0.7.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,9 +34,9 @@ dev_dependencies:
   build_web_compilers: '>=1.2.2 <3.0.0'
 
   shelf_static: ^0.2.8
-  sse: ^2.0.2
+  sse: ^3.6.1
   test: ^1.6.3
-  webdriver: ^2.0.0
+  webdriver: ^3.0.0
 
 executables:
   webdev_proxy:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,6 @@ description: >
   A simple HTTP proxy for webdev's serve command. Supports apps that use HTML5
   routing by rewriting 404s to the root index.
 
-authors:
-  - Workiva Client Platform Team <clientplatform@workiva.com>
-  - Evan Weible <evan.weible@workiva.com>
-
 environment:
   sdk: ">=2.3.2 <3.0.0"
 

--- a/test/chromedriver_utils.dart
+++ b/test/chromedriver_utils.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:webdev_proxy/src/port_utils.dart';
+import 'package:webdriver/io.dart' as wd;
+
+const chromeDriverPort = 4444;
+const chromeDriverUrlBase = 'wd/hub';
+
+Future<void> startChromeDriver() async {
+  try {
+    final chromeDriver = await Process.start(
+        'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+    addTearDown(chromeDriver.kill);
+
+    // On windows this takes a while to boot up, wait for the first line
+    // of stdout as a signal that it is ready.
+    final stdOutLines = chromeDriver.stdout
+        .transform(utf8.decoder)
+        .transform(LineSplitter())
+        .asBroadcastStream();
+
+    final stdErrLines = chromeDriver.stderr
+        .transform(utf8.decoder)
+        .transform(LineSplitter())
+        .asBroadcastStream();
+
+    stdOutLines.listen((line) => print('ChromeDriver stdout: $line'));
+    stdErrLines.listen((line) => print('ChromeDriver stderr: $line'));
+
+    await stdOutLines.first;
+  } catch (e) {
+    throw StateError(
+        'Could not start ChromeDriver. Is it installed?\nError: $e');
+  }
+}
+
+Future<wd.WebDriver> createWebDriver() async {
+  final debugPort = await findUnusedPort();
+  final capabilities = wd.Capabilities.chrome
+    ..addAll({
+      wd.Capabilities.chromeOptions: {
+        'args': [
+          'remote-debugging-port=$debugPort',
+          '--headless',
+        ]
+      }
+    });
+  final webDriver = await wd.createDriver(
+      spec: wd.WebDriverSpec.JsonWire,
+      desired: capabilities,
+      uri: Uri.parse(
+          'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/'));
+  addTearDown(webDriver.quit);
+  return webDriver;
+}

--- a/test/port_utils_test.dart
+++ b/test/port_utils_test.dart
@@ -20,9 +20,9 @@ import 'package:test/test.dart';
 import 'package:webdev_proxy/src/port_utils.dart';
 
 void main() {
-  group('findAndReleaseOpenPort()', () {
+  group('findUnusedPort()', () {
     test('should return an open port', () async {
-      final port = await findAndReleaseOpenPort();
+      final port = await findUnusedPort();
       ServerSocket socket;
       try {
         socket = await ServerSocket.bind('localhost', port);
@@ -34,8 +34,8 @@ void main() {
     });
 
     test('should return distinct ports when called multiple times', () async {
-      final port1 = await findAndReleaseOpenPort();
-      final port2 = await findAndReleaseOpenPort();
+      final port1 = await findUnusedPort();
+      final port2 = await findUnusedPort();
       expect(port1, isNot(port2), reason: 'Ports should be distinct.');
     });
   });

--- a/test/proxy_server_test.dart
+++ b/test/proxy_server_test.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert';
 @TestOn('vm')
 import 'dart:io';
 
@@ -22,45 +21,19 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_static/shelf_static.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:test/test.dart';
-import 'package:webdriver/io.dart';
+import 'package:webdev_proxy/src/port_utils.dart';
 
 import 'package:webdev_proxy/src/webdev_proxy_server.dart';
 
+import 'chromedriver_utils.dart';
+
 void main() {
-  Process chromeDriver;
   WebdevProxyServer proxy;
   HttpServer server;
   SseHandler serverSse;
 
   setUpAll(() async {
-    try {
-      chromeDriver = await Process.start(
-          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
-
-      // On windows this takes a while to boot up, wait for the first line
-      // of stdout as a signal that it is ready.
-      final stdOutLines = chromeDriver.stdout
-          .transform(utf8.decoder)
-          .transform(LineSplitter())
-          .asBroadcastStream();
-
-      final stdErrLines = chromeDriver.stderr
-          .transform(utf8.decoder)
-          .transform(LineSplitter())
-          .asBroadcastStream();
-
-      stdOutLines.listen((line) => print('ChromeDriver stdout: $line'));
-      stdErrLines.listen((line) => print('ChromeDriver stderr: $line'));
-
-      await stdOutLines.first;
-    } catch (e) {
-      throw StateError(
-          'Could not start ChromeDriver. Is it installed?\nError: $e');
-    }
-  });
-
-  tearDownAll(() {
-    chromeDriver.kill();
+    await startChromeDriver();
   });
 
   setUp(() async {
@@ -88,7 +61,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://127.0.0.1:${proxy.port}/index.dart');
+        await http.get('http://localhost:${proxy.port}/index.dart');
     expect(response.statusCode, 200);
     expect(response.body, isNotEmpty);
   });
@@ -96,29 +69,13 @@ void main() {
   test('Proxies the /\$sseHandler endpoint', () async {
     proxy = await WebdevProxyServer.start(
       dir: 'test',
-      hostname: '127.0.0.1',
+      hostname: 'localhost',
       portToProxy: server.port,
       portToServe: await findUnusedPort(),
     );
 
-    print(':::PORTS:::');
-    print('proxy: ${proxy.port}');
-    print('server: ${server.port}');
-    print('chromedriver: http://127.0.0.1:4444/wd/hub');
-
-    final capabilities = Capabilities.chrome
-      ..addAll({
-        Capabilities.chromeOptions: {
-          'args': ['--headless'],
-        }
-      });
-    final webdriver = await createDriver(
-        spec: WebDriverSpec.JsonWire,
-        desired: capabilities,
-        uri: Uri.parse('http://127.0.0.1:4444/wd/hub'));
-    addTearDown(webdriver.quit);
-
-    await webdriver.get('http://127.0.0.1:${proxy.port}');
+    final webDriver = await createWebDriver();
+    await webDriver.get('http://localhost:${proxy.port}');
     var connection = await serverSse.connections.next;
     connection.sink.add('blah');
     expect(await connection.stream.first, 'blah');
@@ -127,13 +84,13 @@ void main() {
   test('Rewrites 404s to /index.html when enabled', () async {
     proxy = await WebdevProxyServer.start(
       dir: 'test',
-      hostname: '127.0.0.1',
+      hostname: 'localhost',
       portToProxy: server.port,
       rewrite404s: true,
     );
 
     final response =
-        await http.get('http://127.0.0.1:${proxy.port}/path/to/nothing');
+        await http.get('http://localhost:${proxy.port}/path/to/nothing');
     expect(response.statusCode, 200);
     expect(response.body, startsWith('<!DOCTYPE html>'));
   });
@@ -141,31 +98,13 @@ void main() {
   test('Does not rewrite 404s to /index.html when disabled', () async {
     proxy = await WebdevProxyServer.start(
       dir: 'test',
-      hostname: '127.0.0.1',
+      hostname: 'localhost',
       portToProxy: server.port,
       rewrite404s: false,
     );
 
     final response =
-        await http.get('http://127.0.0.1:${proxy.port}/path/to/nothing');
+        await http.get('http://localhost:${proxy.port}/path/to/nothing');
     expect(response.statusCode, 404);
   });
-}
-
-/// Returns a port that is probably, but not definitely, not in use.
-///
-/// This has a built-in race condition: another process may bind this port at
-/// any time after this call has returned.
-Future<int> findUnusedPort() async {
-  int port;
-  ServerSocket socket;
-  try {
-    socket =
-        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
-  } on SocketException {
-    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-  }
-  port = socket.port;
-  await socket.close();
-  return port;
 }

--- a/test/proxy_server_test.dart
+++ b/test/proxy_server_test.dart
@@ -31,10 +31,13 @@ void main() {
   HttpServer server;
   SseHandler serverSse;
 
+  const chromeDriverUrlBase = 'wd/hub';
+  const chromeDriverPort = 4444;
+
   setUpAll(() async {
     try {
-      chromeDriver = await Process.start(
-          'chromedriver', ['--port=4444', '--url-base=wd/hub']);
+      chromeDriver = await Process.start('chromedriver',
+          ['--port=$chromeDriverPort', '--url-base=$chromeDriverUrlBase']);
     } catch (e) {
       throw StateError(
           'Could not start ChromeDriver. Is it installed?\nError: $e');
@@ -80,11 +83,17 @@ void main() {
       portToProxy: server.port,
     );
 
-    final webdriver = await createDriver(desired: {
-      'chromeOptions': {
-        'args': ['--headless']
-      }
-    });
+    final capabilities = Capabilities.chrome
+      ..addAll({
+        Capabilities.chromeOptions: {
+          'args': ['--headless']
+        }
+      });
+    final webdriver = await createDriver(
+        spec: WebDriverSpec.JsonWire,
+        desired: capabilities,
+        uri: Uri.parse(
+            'http://127.0.0.1:$chromeDriverPort/$chromeDriverUrlBase/'));
     addTearDown(() async {
       await webdriver.quit();
     });

--- a/test/webdev_arg_utils_test.dart
+++ b/test/webdev_arg_utils_test.dart
@@ -86,6 +86,5 @@ void main() {
       expect(result.hostname, '0.0.0.0');
       expect(result.remainingArgs, ['--release']);
     });
-
   });
 }

--- a/test/webdev_arg_utils_test.dart
+++ b/test/webdev_arg_utils_test.dart
@@ -49,4 +49,43 @@ void main() {
           {'web/nested/dir/': 9000});
     });
   });
+
+  group('parseHostname', () {
+    test('with no args', () {
+      final result = parseHostname([]);
+      expect(result.hostname, 'localhost');
+      expect(result.remainingArgs, []);
+    });
+
+    test('with no hostname arg', () {
+      final result = parseHostname(['--release']);
+      expect(result.hostname, 'localhost');
+      expect(result.remainingArgs, ['--release']);
+    });
+
+    test('--hostname=<value>', () {
+      final result = parseHostname(['--hostname=0.0.0.0']);
+      expect(result.hostname, '0.0.0.0');
+      expect(result.remainingArgs, []);
+    });
+
+    test('--hostname=<value> with trailing args', () {
+      final result = parseHostname(['--hostname=0.0.0.0', '--release']);
+      expect(result.hostname, '0.0.0.0');
+      expect(result.remainingArgs, ['--release']);
+    });
+
+    test('--hostname value', () {
+      final result = parseHostname(['--hostname', '0.0.0.0']);
+      expect(result.hostname, '0.0.0.0');
+      expect(result.remainingArgs, []);
+    });
+
+    test('--hostname value with trailing args', () {
+      final result = parseHostname(['--hostname', '0.0.0.0', '--release']);
+      expect(result.hostname, '0.0.0.0');
+      expect(result.remainingArgs, ['--release']);
+    });
+
+  });
 }

--- a/test/webdev_server_test.dart
+++ b/test/webdev_server_test.dart
@@ -33,7 +33,7 @@ void main() async {
   });
 
   test('Serves a directory', () async {
-    final port = await findAndReleaseOpenPort();
+    final port = await findUnusedPort();
     webdevServer = await WebdevServer.start(['test:$port']);
 
     // We don't have a good way of knowing when the `webdev serve` process has
@@ -42,7 +42,7 @@ void main() async {
     http.Response response;
     while (true) {
       try {
-        response = await http.get('http://localhost:${port}/web/index.dart');
+        response = await http.get('http://localhost:$port/web/index.dart');
       } catch (_) {
         await Future.delayed(Duration(milliseconds: 250));
         continue;


### PR DESCRIPTION
When trying to pass an option like `--hostname=0.0.0.0` from webdev_proxy to the webdev process, we were unintentionally passing the option through twice, which causes a newer version of the build daemon to fail to start.

This PR fixes this by stripping that option and its value out after parsing it.

Additionally, CI has been moved to Github and tests have been updated to work with the latest Chrome and Chromedriver.

## Testing
- [ ] CI passes
- [ ] Test this branch locally on Dart 2.7.2
   - Check out this branch
   - Comment out all `dev_dependencies` (`pub global activate` from path seems to run a pub get which will fail b/c two of the dev deps needed for tests require dart 2.12+)
   - Run `pub global run webdev_proxy --webdev-args="--hostname=0.0.0.0"` in any project with a `web/`