### PR TITLE
Raise the Dart SDK minimum to at least 2.11.0

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ stable, dev ]
+        sdk: [ stable, 2.13.4, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -34,3 +34,4 @@ jobs:
 
       - name: Tests
         run: dart test
+        if: ${{ matrix.sdk == '2.13.4' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Update the minimum Dart SDK version to 2.11.0
+
 ## 0.1.1
 
 - Fix bug when using `--hostname` that would cause the build daemon to fail to

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ index (`/`).
 
 The latest release of `webdev_proxy` requires the following:
 
-- Dart SDK `2.3` or later
+- Dart SDK `2.11` or later
 - `webdev` globally activated at a version in the `>=1.0.1 <3.0.0` range
   - Be sure to follow the [installation instructions for webdev][webdev-install]
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >
   routing by rewriting 404s to the root index.
 
 environment:
-  sdk: ">=2.3.2 <3.0.0"
+  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
   args: ^1.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   # These two build deps are required by webdev.
   build_runner: ^1.5.1
-  build_web_compilers: '>=1.2.2 <3.0.0'
+  build_web_compilers: '>=2.12.0 <3.0.0'
 
   shelf_static: ^0.2.8
   sse: ^3.6.1


### PR DESCRIPTION
## Overview
This updates the minimum Dart version that can be used to at least 2.11.0. Why 2.11.0 and not 2.13.4? Because setting it to 2.12.0 or higher opts the project into null safety (https://dart.dev/null-safety) which our code has not been migrated to yet. 
## What about null safety?
Once a project has been migrated to null safety it is ok to update the  minimum to 2.12.0 or even 2.13.4 since everyone at Workiva should be  using 2.13.4 now.
## Review / Testing / QA / Merge
If CI passes please review and merge. Most Dart CI has already been updated to run under 2.13.4 already so updating the minimum here doesn't change any code, or CI circumstances.
If CI fails, it's likely because an image in the Dockerfile or skynet.yaml is still running an older version of Dart. It should be updated to one with Dart 2.13. A list of existing 2.13 images lives here  https://wiki.atl.workiva.net/display/CP/Dart+2.13+Upgrade Feel free to fix CI and get this PR merged. However if you don't get to it, be aware that Client Platform will be going through the batch to help fix  any failures.
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/up_dart_sdk_minimum_to_2.11`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/up_dart_sdk_minimum_to_2.11)