### PR TITLE
Raise Max Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+- Dependency upgrades
+
 ## 0.1.2
 
 - Update the minimum Dart SDK version to 2.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,22 +11,22 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  args: ^1.5.1
+  args: '>=1.5.1 <3.0.0'
   glob: ^1.1.7
   http: ^0.12.0
   http_multi_server: ^2.1.0
   io: ^0.3.3
-  logging: ^0.11.3+2
+  logging: '>=0.11.3+2 <2.0.0'
   meta: ">=1.1.7 <1.7.0" # pin to avoid issue in 1.7.0
   pedantic: ^1.7.0
-  pub_semver: ^1.4.2
+  pub_semver: '>=1.4.2 <3.0.0'
   shelf: ^0.7.2
   shelf_proxy: ^0.1.0
   stack_trace: ^1.9.3
 
 dev_dependencies:
   # These two build deps are required by webdev.
-  build_runner: ^1.5.1
+  build_runner: '>=1.5.1 <3.0.0'
   build_web_compilers: '>=2.12.0 <3.0.0'
 
   shelf_static: ^0.2.8


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)