### PR TITLE
TEST: Compatibility with pkg:http ^0.13.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,3 +36,6 @@ dev_dependencies:
 
 executables:
   webdev_proxy:
+
+dependency_overrides:
+  http: '>=0.13.0 <0.13.4'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!
Read more details at https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

The purpose of this batch is to find packages that depend on the `http`
package and add a dependency override to force resolution to the next major
version (^0.13.0) in order to test for compatibility.

**There is no immediate action required on your part.**

If CI passes, we will consider that verification that the packages in this
repo are compatible with `pkg:http ^0.13.0`. Otherwise, the FEF team will
investigate the CI failure to determine if any action is needed to unblock
this upgrade.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/test2_http_13`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test2_http_13)