### PR TITLE
Unblock Analyzer 1

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -33,5 +33,5 @@ jobs:
         run: dart analyze
 
       - name: Tests
-        run: dart test
+        run: dart test --chain-stack-traces
         if: ${{ matrix.sdk == '2.13.4' }}

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ stable, 2.13.4, dev ]
+        sdk: [ stable, 2.13.4 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
   meta: ">=1.1.7 <1.7.0" # pin to avoid issue in 1.7.0
   pedantic: ^1.7.0
   pub_semver: '>=1.4.2 <3.0.0'
-  shelf: ^0.7.2
-  shelf_proxy: ^0.1.0
+  shelf: ^1.0.0
+  shelf_proxy: ^1.0.0
   stack_trace: ^1.9.3
 
 dev_dependencies:
@@ -29,8 +29,8 @@ dev_dependencies:
   build_runner: '>=1.5.1 <3.0.0'
   build_web_compilers: '>=2.12.0 <3.0.0'
 
-  shelf_static: ^0.2.8
-  sse: ^3.6.1
+  shelf_static: ^1.0.0
+  sse: ^4.0.0
   test: ^1.6.3
   webdriver: ^3.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,27 +11,27 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  args: '>=1.5.1 <3.0.0'
-  glob: ^2.0.0
-  http: ^0.13.0
-  http_multi_server: ^2.1.0
-  io: '>=0.3.3 <2.0.0'
-  logging: '>=0.11.3+2 <2.0.0'
-  meta: ">=1.1.7 <1.7.0" # pin to avoid issue in 1.7.0
-  pedantic: ^1.7.0
-  pub_semver: '>=1.4.2 <3.0.0'
-  shelf: ^1.0.0
+  args: ^2.3.1
+  glob: ^2.0.1
+  http: ^0.13.3
+  http_multi_server: ^3.2.1
+  io: ^1.0.3
+  logging: ^1.1.0
+  meta: ^1.8.0
+  pedantic: ^1.11.1
+  pub_semver: ^2.1.2
+  shelf: ^1.2.0
   shelf_proxy: ^1.0.0
-  stack_trace: ^1.9.3
+  stack_trace: ^1.10.0
 
 dev_dependencies:
   # These two build deps are required by webdev.
-  build_runner: '>=1.5.1 <3.0.0'
-  build_web_compilers: '>=2.12.0 <3.0.0'
+  build_runner: ^2.1.2
+  build_web_compilers: ^3.0.0
 
-  shelf_static: ^1.0.0
-  sse: ^4.0.0
-  test: ^1.6.3
+  shelf_static: ^1.1.0
+  sse: ^4.1.0
+  test: ^1.17.12
   webdriver: ^3.0.0
 
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   args: '>=1.5.1 <3.0.0'
-  glob: ^1.1.7
-  http: ^0.12.0
+  glob: ^2.0.0
+  http: ^0.13.0
   http_multi_server: ^2.1.0
   io: '>=0.3.3 <2.0.0'
   logging: '>=0.11.3+2 <2.0.0'

--- a/test/proxy_server_test.dart
+++ b/test/proxy_server_test.dart
@@ -61,7 +61,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://localhost:${proxy.port}/index.dart');
+        await http.get(Uri.parse('http://localhost:${proxy.port}/index.dart'));
     expect(response.statusCode, 200);
     expect(response.body, isNotEmpty);
   });
@@ -90,7 +90,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://localhost:${proxy.port}/path/to/nothing');
+        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 200);
     expect(response.body, startsWith('<!DOCTYPE html>'));
   });
@@ -104,7 +104,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://localhost:${proxy.port}/path/to/nothing');
+        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 404);
   });
 }

--- a/test/proxy_server_test.dart
+++ b/test/proxy_server_test.dart
@@ -89,8 +89,8 @@ void main() {
       rewrite404s: true,
     );
 
-    final response =
-        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
+    final response = await http
+        .get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 200);
     expect(response.body, startsWith('<!DOCTYPE html>'));
   });
@@ -103,8 +103,8 @@ void main() {
       rewrite404s: false,
     );
 
-    final response =
-        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
+    final response = await http
+        .get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 404);
   });
 }

--- a/test/webdev_proxy_server_test.dart
+++ b/test/webdev_proxy_server_test.dart
@@ -60,7 +60,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://localhost:${proxy.port}/index.dart');
+        await http.get(Uri.parse('http://localhost:${proxy.port}/index.dart'));
     expect(response.statusCode, 200);
     expect(response.body, isNotEmpty);
   });
@@ -88,7 +88,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://localhost:${proxy.port}/path/to/nothing');
+        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 200);
     expect(response.body, startsWith('<!DOCTYPE html>'));
   });
@@ -102,7 +102,7 @@ void main() {
     );
 
     final response =
-        await http.get('http://localhost:${proxy.port}/path/to/nothing');
+        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 404);
   });
 }

--- a/test/webdev_proxy_server_test.dart
+++ b/test/webdev_proxy_server_test.dart
@@ -87,8 +87,8 @@ void main() {
       rewrite404s: true,
     );
 
-    final response =
-        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
+    final response = await http
+        .get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 200);
     expect(response.body, startsWith('<!DOCTYPE html>'));
   });
@@ -101,8 +101,8 @@ void main() {
       rewrite404s: false,
     );
 
-    final response =
-        await http.get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
+    final response = await http
+        .get(Uri.parse('http://localhost:${proxy.port}/path/to/nothing'));
     expect(response.statusCode, 404);
   });
 }

--- a/test/webdev_server_test.dart
+++ b/test/webdev_server_test.dart
@@ -42,7 +42,7 @@ void main() async {
     http.Response response;
     while (true) {
       try {
-        response = await http.get('http://localhost:$port/web/index.dart');
+        response = await http.get(Uri.parse('http://localhost:$port/web/index.dart'));
       } catch (_) {
         await Future.delayed(Duration(milliseconds: 250));
         continue;

--- a/test/webdev_server_test.dart
+++ b/test/webdev_server_test.dart
@@ -42,7 +42,8 @@ void main() async {
     http.Response response;
     while (true) {
       try {
-        response = await http.get(Uri.parse('http://localhost:$port/web/index.dart'));
+        response =
+            await http.get(Uri.parse('http://localhost:$port/web/index.dart'));
       } catch (_) {
         await Future.delayed(Duration(milliseconds: 250));
         continue;


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

## Changes

```
  # dev dependencies, raise min
  pubspec_codemod raise-min w_common_tools 2.0.0 --recursive
  pubspec_codemod raise-min dart_dev_workiva 2.0.0 --recursive
  pubspec_codemod raise-min mockito 5.0.0 --recursive
  pubspec_codemod raise-min glob 2.0.0 --recursive
  pubspec_codemod raise-min puppeteer 2.0.0 --recursive
  pubspec_codemod raise-min puppeteer_platform 1.3.0 --recursive
  
  # dependencies, raise min
  pubspec_codemod raise-min http 0.13.0 --recursive
  pubspec_codemod raise-min dio 4.0.0 --recursive

  # dependencies, raise max
  pubspec_codemod raise-max intl 0.18.0 --recursive
  pubspec_codemod raise-max archive 4.0.0 --recursive
  pubspec_codemod raise-max yaml 4.0.0 --recursive
  pubspec_codemod raise-max markdown 6.0.0 --recursive
  pubspec_codemod raise-max xml 6.0.0 --recursive
  pubspec_codemod remove tuneup
```

## Process

Someone from FEF will prepare this PR, fix any issues and move 
it out of draft state when it's ready.

markdown 5 and xml 5 have been tested in w_table and w_filing
but teams should do manual testing of processes that require
xml or markdown. (Once the PR is ready)
For all the other updates, a resolving pub get to analyzer 1+ and
passing CI should be good.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/unblock_analyzer1`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/unblock_analyzer1)