### PR TITLE
RM-168215 Release webdev_proxy 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.1.8
+
+- Dependency upgrades https://github.com/Workiva/webdev_proxy/pull/26
+
+## 0.1.7
+
+- #24 Use dart pub instead of just pub
+
+## 0.1.6
+
+- Dependency upgrades #20
+
+## 0.1.5
+
+- #19 Replace deprecated commands with new dart commands
+
+## 0.1.4
+
+- #17 Fix wildcard to include branch names with slashes
+
 ## 0.1.3
 
 - Dependency upgrades

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev_proxy
-version: 0.1.7
+version: 0.1.8
 private: true
 homepage: https://github.com/Workiva/webdev_proxy
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Unblock Analyzer 1](https://github.com/Workiva/webdev_proxy/pull/26)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/webdev_proxy/compare/0.1.7...Workiva:release_webdev_proxy_0.1.8
Diff Between Last Tag and New Tag: https://github.com/Workiva/webdev_proxy/compare/0.1.7...0.1.8

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6743830263234560/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6743830263234560/?repo_name=Workiva%2Fwebdev_proxy&pull_number=27)