### PR TITLE
RM-173749 Release webdev_proxy 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9
+
+- Updated to null safety. Dart SDK minimum of 2.12.
+
 ## 0.1.8
 
 - Dependency upgrades https://github.com/Workiva/webdev_proxy/pull/26

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev_proxy
-version: 0.1.8
+version: 0.1.9
 private: true
 homepage: https://github.com/Workiva/webdev_proxy
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Migrate to null safety](https://github.com/Workiva/webdev_proxy/pull/28)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/webdev_proxy/compare/0.1.8...Workiva:release_webdev_proxy_0.1.9
Diff Between Last Tag and New Tag: https://github.com/Workiva/webdev_proxy/compare/0.1.8...0.1.9

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6743830263234560/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6743830263234560/?repo_name=Workiva%2Fwebdev_proxy&pull_number=30)