### PR TITLE
Dart 2.19

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7, stable ]
+        sdk: [ 2.18.7, 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:2
 WORKDIR /build/
 ADD pubspec.yaml .
 RUN dart pub get

--- a/lib/src/sse_proxy_handler.dart
+++ b/lib/src/sse_proxy_handler.dart
@@ -84,7 +84,6 @@ class SseProxyHandler {
         sink.close();
       });
     });
-    return shelf.Response.notFound('');
   }
 
   Future<shelf.Response> _handle(shelf.Request req) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >
   routing by rewriting 404s to the root index.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   args: ^2.3.1

--- a/test/chromedriver_utils.dart
+++ b/test/chromedriver_utils.dart
@@ -18,8 +18,8 @@ Future<void> startChromeDriver() async {
       }
     });
 
-    // On windows this takes a while to boot up, wait for the first line
-    // of stdout as a signal that it is ready.
+    // On windows this takes a while to boot up, wait for a message on stdout
+    // indicating ChromeDriver started successfully.
     final stdOutLines = chromeDriver.stdout
         .transform(utf8.decoder)
         .transform(LineSplitter())
@@ -33,7 +33,8 @@ Future<void> startChromeDriver() async {
     stdOutLines.listen((line) => print('ChromeDriver stdout: $line'));
     stdErrLines.listen((line) => print('ChromeDriver stderr: $line'));
 
-    await stdOutLines.first;
+    await stdOutLines.firstWhere(
+        (line) => line.contains('ChromeDriver was started successfully'));
   } catch (e) {
     throw StateError(
         'Could not start ChromeDriver. Is it installed?\nError: $e');

--- a/test/chromedriver_utils.dart
+++ b/test/chromedriver_utils.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:webdev_proxy/src/port_utils.dart';
-import 'package:webdriver/io.dart' as wd;
+import 'package:webdriver/async_io.dart' as wd;
 
 const chromeDriverPort = 4444;
 const chromeDriverUrlBase = 'wd/hub';

--- a/test/sse_proxy_handler_test.dart
+++ b/test/sse_proxy_handler_test.dart
@@ -8,7 +8,7 @@ import 'package:shelf_static/shelf_static.dart';
 import 'package:sse/server/sse_handler.dart';
 import 'package:test/test.dart';
 import 'package:webdev_proxy/src/port_utils.dart';
-import 'package:webdriver/io.dart';
+import 'package:webdriver/async_io.dart';
 
 import 'package:webdev_proxy/src/sse_proxy_handler.dart';
 


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_2_19`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_2_19)