### PR TITLE
RM-221315 Release webdev_proxy 0.1.11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev_proxy
-version: 0.1.10
+version: 0.1.11
 private: true
 homepage: https://github.com/Workiva/webdev_proxy
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Update serve_command.dart](https://github.com/Workiva/webdev_proxy/pull/38)


Requested by: @todbachman-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/webdev_proxy/compare/0.1.10...Workiva:release_webdev_proxy_0.1.11
Diff Between Last Tag and New Tag: https://github.com/Workiva/webdev_proxy/compare/0.1.10...0.1.11

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6743830263234560/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6743830263234560/?repo_name=Workiva%2Fwebdev_proxy&pull_number=39)