### PR TITLE
Newer deps to get to analyzer 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.12
+
+- Update ranges of dependencies so that in Dart 3 we can resolve to analyzer 6, while still working with Dart 2.19. https://github.com/Workiva/webdev_proxy/pull/46
+
 ## 0.1.11
 
 - Update webdev installation message to use `dart pub global activate` rather

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
 dev_dependencies:
   # These two build deps are required by webdev.
   build_runner: ^2.1.2
-  build_test: ^2.0.0
   build_web_compilers: '>3.0.0 <5.0.0'
   lints: '>=2.0.1 <5.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   args: ^2.3.1
-  http: ^0.13.3
+  http: '>=0.13.3 <2.0.0'
   http_multi_server: ^3.2.1
   io: ^1.0.3
   logging: ^1.1.0
@@ -25,8 +25,8 @@ dependencies:
 dev_dependencies:
   # These two build deps are required by webdev.
   build_runner: ^2.1.2
-  build_web_compilers: ^3.0.0
-  lints: ^2.0.1
+  build_web_compilers: '>3.0.0 <5.0.0'
+  lints: '>=2.0.1 <5.0.0'
 
   shelf_static: ^1.1.0
   sse: ^4.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 dev_dependencies:
   # These two build deps are required by webdev.
   build_runner: ^2.1.2
+  build_test: ^2.0.0
   build_web_compilers: '>3.0.0 <5.0.0'
   lints: '>=2.0.1 <5.0.0'
 

--- a/test/sse_proxy_handler_test.dart
+++ b/test/sse_proxy_handler_test.dart
@@ -128,8 +128,7 @@ void main() {
     await webdriver.get('http://localhost:${proxy.port}');
     await serverSse.connections.next;
     expect(serverSse.numberOfClients, 1);
-
-    await webdriver.get('about:blank');
+    await webdriver.quit();
     expect(serverSse.numberOfClients, 0);
   });
 }

--- a/test/sse_proxy_handler_test.dart
+++ b/test/sse_proxy_handler_test.dart
@@ -129,9 +129,7 @@ void main() {
     await serverSse.connections.next;
     expect(serverSse.numberOfClients, 1);
 
-    await webdriver.get('chrome://version/');
-    await Future.delayed(Duration(seconds: 1));
-
+    await webdriver.get('about:blank');
     expect(serverSse.numberOfClients, 0);
   });
 }

--- a/test/sse_proxy_handler_test.dart
+++ b/test/sse_proxy_handler_test.dart
@@ -130,6 +130,8 @@ void main() {
     expect(serverSse.numberOfClients, 1);
 
     await webdriver.get('chrome://version/');
+    await Future.delayed(Duration(seconds: 1));
+
     expect(serverSse.numberOfClients, 0);
   });
 }

--- a/test/webdev_proc_utils_test.dart
+++ b/test/webdev_proc_utils_test.dart
@@ -37,19 +37,15 @@ void main() {
       expect(getGlobalWebdevVersion(), isNull);
     });
 
-    test('with webdev activated (dart 2)', () async {
-      print(Platform.version);
+    test('with webdev activated', () async {
       if (Platform.version.contains('2.19')) {
         await activateWebdev('2.0.0');
         expect(getGlobalWebdevVersion(), Version.parse('2.0.0'));
-      }
-    });
-
-    test('with webdev activated (dart 3)', () async {
-      print(Platform.version);
-      if (Platform.version.contains('3.')) {
+      } else if (Platform.version.contains('3.')) {
         await activateWebdev('3.0.0');
         expect(getGlobalWebdevVersion(), Version.parse('3.0.0'));
+      } else {
+        throw Exception('Unsupported Dart version: ${Platform.version}');
       }
     });
   });

--- a/test/webdev_proc_utils_test.dart
+++ b/test/webdev_proc_utils_test.dart
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 @TestOn('vm')
+import 'dart:io';
+
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
@@ -35,9 +37,20 @@ void main() {
       expect(getGlobalWebdevVersion(), isNull);
     });
 
-    test('with webdev activated', () async {
-      await activateWebdev('>=2.0.0 <4.0.0');
-      expect(getGlobalWebdevVersion(), Version.parse('2.0.0'));
+    test('with webdev activated (dart 2)', () async {
+      print(Platform.version);
+      if (Platform.version.contains('2.19')) {
+        await activateWebdev('2.0.0');
+        expect(getGlobalWebdevVersion(), Version.parse('2.0.0'));
+      }
+    });
+
+    test('with webdev activated (dart 3)', () async {
+      print(Platform.version);
+      if (Platform.version.contains('3.')) {
+        await activateWebdev('3.0.0');
+        expect(getGlobalWebdevVersion(), Version.parse('3.0.0'));
+      }
     });
   });
 

--- a/test/webdev_proc_utils_test.dart
+++ b/test/webdev_proc_utils_test.dart
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('with webdev activated', () async {
-      await activateWebdev('2.0.0');
+      await activateWebdev('>=2.0.0 <4.0.0');
       expect(getGlobalWebdevVersion(), Version.parse('2.0.0'));
     });
   });


### PR DESCRIPTION
# Summary

Update ranges of dependencies so that in Dart 3 we can resolve to analyzer 6, while still working with Dart 2.19.
Running tests under Dart 3 exposed the need to fix 2 of them.

# Testing
CI passes under both Dart 2.19 and Dart 3