### PR TITLE
RM-229546 Release webdev_proxy 0.1.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
 
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@fixed_validate-publish-condition
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
 
   test-unit:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
 
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@fixed_validate-publish-condition
 
   test-unit:
     strategy:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdev_proxy
-version: 0.1.11
+version: 0.1.12
 private: true
 homepage: https://github.com/Workiva/webdev_proxy
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [DSC-10122 - Complete transition to GHA](https://github.com/Workiva/webdev_proxy/pull/43)
	* [fix: Support for webdev 3.0](https://github.com/Workiva/webdev_proxy/pull/44)
	* [FEA-4627: fedx_codeowners_file](https://github.com/Workiva/webdev_proxy/pull/45)
	* [Newer deps to get to analyzer 6](https://github.com/Workiva/webdev_proxy/pull/46)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/webdev_proxy/compare/0.1.11...Workiva:release_webdev_proxy_0.1.12
Diff Between Last Tag and New Tag: https://github.com/Workiva/webdev_proxy/compare/0.1.11...0.1.12

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6743830263234560/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6743830263234560/?repo_name=Workiva%2Fwebdev_proxy&pull_number=47)