### PR TITLE
Fix comment about the default hostname

### DIFF
--- a/lib/src/serve_command.dart
+++ b/lib/src/serve_command.dart
@@ -135,7 +135,7 @@ class ServeCommand extends Command<int> {
       shutDown(ExitCode.success.code);
     });
 
-    // Parse the hostname to serve each dir on (defaults to 0.0.0.0)
+    // Parse the hostname to serve each dir on (defaults to localhost).
     final hostnameResults = parseHostname(argResults!.rest);
     final hostname = hostnameResults.hostname;
     final remainingArgs = hostnameResults.remainingArgs;


### PR DESCRIPTION
The comment says the default hostname is `0.0.0.0`.

However, if we check the method implementation, the default hostname is actually `localhost`:

![image](https://github.com/user-attachments/assets/64743993-81fe-4369-aa33-31800edf1130)
